### PR TITLE
fixing header_prediction module

### DIFF
--- a/ml/header_predictions.py
+++ b/ml/header_predictions.py
@@ -5,7 +5,8 @@ _confidence = .99
 
 
 def predict_headers_and_pre_processing(path, obj):
-    model = HeaderPredictions().predict(predict_path=path, obj=obj)
+    model = HeaderPredictions()
+    model.predict(predict_path=path, obj=obj)
     headers = model.p_df.columns.values
     print("Here are the headers in the '%s' file: \n\n %s \n" % (model.predict_file_name, headers))
     output = make_df(data={"1. Header": headers, "3. Prediction": model.predictions})


### PR DESCRIPTION
fixes #79 and resolves #79 

in initializing the HeaderPrediction class and invoking the .predict()
method the variable that this call was assigned to was not inheriting
the variables associated to the HeaderPrediction object.

this was fixed by breaking these calls up into two seperate lines.
model = HeaderPredictions()
model.predict(xyz_file, xyz_obj)