### PR TITLE
Auto attach email requests to sfdc

### DIFF
--- a/created_contacts_to_campaign.py
+++ b/created_contacts_to_campaign.py
@@ -1,0 +1,44 @@
+from utility.log_helper import ListManagementLogger
+from sf.sf_wrapper import SFPlatform
+from cred import sfuser, sfpw, sf_token
+from sqlalchemy import create_engine
+import pandas as pd
+
+log = ListManagementLogger().logger
+log.info('Starting conference creation contact processing.')
+log.info('Initializing variables and objects.')
+sfdc = SFPlatform(user=sfuser, pw=sfpw, token=sf_token, log=log)
+engine = create_engine('mssql+pyodbc://DPHL-PROPSCORE/ListManagement?driver=SQL+Server')
+sql = "SELECT ObjId, SourceChannel, Status FROM [dbo].[ConferenceCreation] WHERE AddedToCampaign=0"
+
+log.info('Reading data from ListManagement database.')
+data = pd.read_sql(sql=sql, con=engine).values
+
+if len(data) < 1:
+    log.info('There are no new contacts that need to be associated with a campaign. Trying again tomorrow morning.')
+else:
+    soql = "SELECT Id, Source_Channel__c FROM Contact WHERE Source_Channel__c IN ('%s')" % "','".join([x[1]
+                                                                                                       for x in data])
+    log.info('Grabbing data, based on Source_Channel__c, from SFDC.')
+    result = sfdc.session.selectRecords(soql)
+
+    log.info('Creating data mappings for SFDC campaign upload.')
+    mappings = {x[1]: [] for x in data}
+    for rec in result:
+        for x in data:
+            if rec.Source_Channel__c == x[1]:
+                mappings[x[1]].append([rec.Id, x[2], x[0]])
+
+    log.info('Attempting to associate new contacts to the campaign related to the list request. ')
+    messages = []
+    for k, v in mappings.iteritems():
+        if len(v) > 0:
+            log.info(
+                'Creating %s campaign member records to %s campaign id with a source channel of %s.' % (len(v), v[0][2],
+                                                                                                        k))
+            sfdc.create_records(obj='CampaignMember', fields=['ContactId', 'Status', 'CampaignId'], upload_data=v)
+            sql = "UPDATE [dbo].[ConferenceCreation] SET AddedToCampaign=1 WHERE SourceChannel='%s'" % k
+            engine.execute(sql)
+
+sfdc.close_session()
+engine.dispose()

--- a/list_processing.py
+++ b/list_processing.py
@@ -1,5 +1,5 @@
 import traceback
-from ListManagement.utility.email_wrapper import Email
+from utility.email_wrapper import Email
 from finra.finra import FinraScraping
 from ml.header_predictions import predict_headers_and_pre_processing
 from search.search import Search

--- a/list_processing.py
+++ b/list_processing.py
@@ -161,6 +161,9 @@ class ListProcessing:
         self.vars['SFDC Session'].last_list_uploaded(obj_id=self.vars['ObjectId'], obj=self.vars['Object'])
         self.vars.update(source_channel(self.vars['update_path'], self.vars['Record Name'],
                                         self.vars['ObjectId'], self.vars['Object'], log=self.log))
+        self.vars.update(source_channel(self.vars['to_create_path'], self.vars['Record Name'],
+                                        self.vars['ObjectId'], self.vars['Object'],
+                                        self.vars['ObjectId'], log=self.log))
         self.vars.update(extract_dictionary_values(dict_data=self.vars, log=self.log))
 
         if self.vars['Move To Bulk']:

--- a/search/Search.py
+++ b/search/Search.py
@@ -285,7 +285,6 @@ class Search:
         return self
 
     def _lkup_name_address_processing(self, headers, search_list):
-        # If we have the information to make LkupName, do so
         """
         helper method to create the LkupName search field, if the necessary columns are present, and pre-process them.
     
@@ -301,24 +300,36 @@ class Search:
         :return: transformed data frame
         """
         if "MailingPostalCode" in headers and "MailingState" in headers:
+            import us
+            import uszipcode
+            zs = uszipcode.ZipcodeSearchEngine()
 
             search_list['MailingPostalCode'] = search_list['MailingPostalCode'].astype(str)
-            for index, row in search_list.iterrows():
-                search_list.loc[index, "MailingPostalCode"] = row["MailingPostalCode"].split('-')[0]
-                if len(row["MailingPostalCode"]) == 9:
-                    search_list.loc[index, "MailingPostalCode"] = row["MailingPostalCode"][:5]
-                elif len(row["MailingPostalCode"]) == 8:
-                    search_list.loc[index, "MailingPostalCode"] = row["MailingPostalCode"][:4]
 
-            if np.mean(search_list['MailingState'].str.len()) > 2:
-                import us
-                self.log.info('MailingState column needs to be transformed.')
-                for index, row in search_list.iterrows():
-                    try:
-                        state = us.states.lookup(search_list.loc[index, "MailingState"])
-                        search_list.loc[index, "MailingState"] = str(state.abbr)
-                    except:
-                        pass
+            search_list['MailingPostalCode'] = search_list.apply(
+                lambda x: x['MailingPostalCode'].split('-')[0] if '-' in x['MailingPostalCode'] else x[
+                    'MailingPostalCode'], axis=1)
+
+            search_list['MailingPostalCode'] = search_list.apply(
+                lambda x: x['MailingPostalCode'][:5] if len(x['MailingPostalCode']) == 9 else x['MailingPostalCode'],
+                axis=1)
+
+            search_list['MailingPostalCode'] = search_list.apply(
+                lambda x: str(0) + x['MailingPostalCode'][:4] if len(x['MailingPostalCode']) == 8 else x[
+                    'MailingPostalCode'], axis=1)
+
+            try:
+                search_list['MailingState'] = search_list.apply(
+                    lambda x: us.states.lookup(unicode(x['MailingState']), use_cache=False).abbr if len(
+                        x['MailingState']) > 2 else x['MailingState'], axis=1)
+            except:
+                try:
+                    self.log.info("Unable to transform MailingState with the python 'us' library.")
+                    search_list['MailingState'] = search_list.apply(
+                        lambda x: zs.by_zipcode(x['MailingPostalCode'])['State'], axis=1)
+                except:
+                    self.log.info("Unable to transform MailingState with the python 'uszipcode' library.")
+                    self.log.info('Will forgo attempting to transform MailingState')
 
             if "FirstName" in headers and "LastName" in headers:
                 search_list["FirstName"] = map(lambda x: x.title(), search_list["FirstName"])

--- a/sf/sf_wrapper.py
+++ b/sf/sf_wrapper.py
@@ -1,6 +1,7 @@
 import SQLForce
 from SQLForce import AttachmentReader, AttachmentWriter
 from utility.gen_helper import convert_unicode_to_date, create_dir_move_file, split_name
+import traceback
 import os
 import shutil
 
@@ -11,7 +12,7 @@ class SFPlatform:
     
     """
 
-    def __init__(self, user, pw, token):
+    def __init__(self, user, pw, token, log=None):
         """
         declare the objects attribute values and authenticate the user.
         
@@ -19,6 +20,7 @@ class SFPlatform:
         :param pw: sf_password 
         :param token: sf_secret_token
         """
+        self.log = log
         self._save_dir = 'T:/Shared/FS2 Business Operations/Python Search Program/New Lists/'
         self._custom_domain = 'https://fsinvestments.my.salesforce.com:'
         self.session = self._auth(user, pw, token)
@@ -127,11 +129,12 @@ class SFPlatform:
         for att in attachments:
             if len(att) >= 120:
                 att = self.__manage_attachements__(att=att)
-            print('Attaching %s to %s list record.' % (att, obj_id))
+            self.log.info('Attaching %s to %s list record.' % (att, obj_id))
             try:
                 AttachmentWriter.attachFile(session=self.session, parentId=obj_id, filename=att)
             except:
-                print('Unable to attach the %s file. I suggest it gets uploaded manually.' % att)
+                self.log.warn('Unable to attach the %s file. I suggest it gets uploaded manually.' % att)
+                self.log.warn(str(traceback.format_exc()))
         self.__clean_up_attachments__()
 
     def last_list_uploaded(self, obj_id, obj, success=False):

--- a/sf/sf_wrapper.py
+++ b/sf/sf_wrapper.py
@@ -1,6 +1,6 @@
 import SQLForce
 from SQLForce import AttachmentReader, AttachmentWriter
-from utility.gen_helper import convert_unicode_to_date, create_dir_move_file, split_name
+from utility.gen_helper import convert_unicode_to_date, create_dir_move_file, split_name, determine_ext
 import traceback
 import os
 import shutil
@@ -127,8 +127,7 @@ class SFPlatform:
         :return: n/a
         """
         for att in attachments:
-            if len(att) >= 120:
-                att = self.__manage_attachements__(att=att)
+            att = self.__manage_attachements__(att=att)
             self.log.info('Attaching %s to %s list record.' % (att, obj_id))
             try:
                 AttachmentWriter.attachFile(session=self.session, parentId=obj_id, filename=att)
@@ -202,7 +201,10 @@ class SFPlatform:
         if not os.path.isdir(self.__att_drive__):
             os.mkdir(self.__att_drive__)
         file_name_list = split_name(att).replace('-', ' ').replace('_', ' ').split(' ')
-        new_name = self.__att_drive__ + ' '.join(file_name_list[:2]) + ' ' + ' '.join(file_name_list[-2:])
+        if len(file_name_list) > 2:
+            new_name = self.__att_drive__ + ' '.join(file_name_list[:2]) + ' ' + ' '.join(file_name_list[-2:])
+        else:
+            new_name = self.__att_drive__ + ' '.join(file_name_list)
         shutil.copy(att, new_name)
         return new_name
 

--- a/utility/email_reader.py
+++ b/utility/email_reader.py
@@ -324,7 +324,7 @@ class MailBoxReader:
         try:
             self.log.info('Attempting to upload emailed list request to SFDC and attach links.')
             sfdc.update_records(dict_data['object'], data_pkg[0], [data_pkg[1]])
-            sfdc.upload_attachments(dict_data['object'], att)
+            sfdc.upload_attachments(dict_data['link'], att)
         except:
             self.log.warn('There was an issue updating and uploading data to the %s record.' % dict_data['object'])
             sfdc.close_session()

--- a/utility/email_reader.py
+++ b/utility/email_reader.py
@@ -73,7 +73,8 @@ class MailBoxReader:
     def handle_new_email_requests(self, num, raw_email):
         attmts = list()
         tmp_dict = dict()
-        tmp_dict['has_link'] = 'not set'
+        tmp_dict.update({'has_link': 'not set', 'link': None, 'object': None,
+                         'search_link': "https://fsinvestments.my.salesforce.com"})
         tmp_dict['name'], tmp_dict['email'] = parseaddr(raw_email['From'])[0], parseaddr(raw_email['From'])[1]
         tmp_dict['sub'], tmp_dict['date'] = raw_email['subject'], datetime.datetime.strftime(parse(raw_email['date']),
                                                                                              '%m/%d/%Y %H:%M:%S')
@@ -82,7 +83,9 @@ class MailBoxReader:
             if part.get_content_type().lower() == "text/html" and tmp_dict['has_link'] == 'not set':
                 e_body = fromstring(part.get_payload(decode=True)).text_content()
                 e_body = e_body[e_body.find("-->") + 3:]
-                tmp_dict['has_link'] = e_body.find("https://fsinvestments.my.salesforce.com")
+                tmp_dict['has_link'] = e_body.find(tmp_dict['search_link'])
+                if tmp_dict['has_link'] not in ['not set', -1]:
+                    tmp_dict = self.determine_id_and_object_from_link(tmp=tmp_dict, email_text=e_body)
                 msg_body += re.sub(r'[^\x00-\x7F]+', ' ', e_body)
 
             if part.get_content_maintype() == "mulipart": continue
@@ -100,6 +103,21 @@ class MailBoxReader:
             msg, msg_body = self.get_decoded_email_body(f_data[0][1])
             list_queue.append([msg, msg_body, num])
         return list_queue
+
+    def determine_id_and_object_from_link(self, tmp, email_text):
+        end_point = tmp['has_link'] + len(tmp['search_link']) + 16
+        tmp['link'] = email_text[tmp['has_link'] + len(tmp['search_link']) + 1: end_point]
+        if tmp['link'][:3] == '001':
+            tmp['object'] = 'Account'
+        elif tmp['link'][:3] == 'a0v':
+            tmp['object'] = 'BizDev__c'
+        elif tmp['link'][:3] == '701':
+            tmp['object'] = 'Campaign'
+        else:
+            tmp['object'] = None
+            self.log.warn('Unable to determine object from Salesforce link. You will need to manually upload'
+                          'the list Salesforce for the new list request.')
+        return tmp
 
     def iterative_processing(self, msg_list):
         msg = msg_list[0]
@@ -298,6 +316,19 @@ class MailBoxReader:
             sub = 'New List Received. Check List Management Trello Board'
             msg_body = "https://trello.com/b/KhPmn9qK/sf-lists-leads\n\n" + msg_body
             Email(subject=sub, to=_list_team, body=msg_body, attachment_path=att)
+            self.associate_email_request_with_sf_object(dict_data=dict_data, att=att)
+
+    def associate_email_request_with_sf_object(self, dict_data, att):
+        sfdc = SFPlatform(user=sfuser, pw=sfpw, token=sf_token, log=self.log)
+        data_pkg = [['List_Upload__c'], [dict_data['link'], 'True']]
+        try:
+            self.log.info('Attempting to upload emailed list request to SFDC and attach links.')
+            sfdc.update_records(dict_data['object'], data_pkg[0], [data_pkg[1]])
+            sfdc.upload_attachments(dict_data['object'], att)
+        except:
+            self.log.warn('There was an issue updating and uploading data to the %s record.' % dict_data['object'])
+            sfdc.close_session()
+            pass
 
 # m = MailBoxReader()
 # for i in range(m.pending_lists['Lists_In_Queue']):

--- a/utility/gen_helper.py
+++ b/utility/gen_helper.py
@@ -5,8 +5,10 @@ import datetime
 import shutil
 import errno
 import ntpath
+from sqlalchemy import create_engine
 from dateutil.parser import parse
 from cred import userPhone, userEmail, userName, sf_uid
+import pandas as pd
 
 userName = userName
 userEmail = userEmail
@@ -187,6 +189,15 @@ def determine_move_to_bulk_processing(df):
     if len(df.index) == 0:
         move = False
     return move
+
+
+def save_conf_creation_meta(sc, id):
+    engine = create_engine('mssql+pyodbc://DPHL-PROPSCORE/ListManagement?driver=SQL+Server')
+    data_package = [['Date', 'ObjId', 'SourceChannel', 'AddedToCampaign'],
+                    [time_now, id, sc, False]]
+    df = pd.DataFrame(data_package[1], data_package[0])
+    df.to_sql('ConferenceCreation', con=engine, index=False, if_exists='append')
+    engine.close()
 
 
 def remove_underscores(line):

--- a/utility/gen_helper.py
+++ b/utility/gen_helper.py
@@ -191,13 +191,14 @@ def determine_move_to_bulk_processing(df):
     return move
 
 
-def save_conf_creation_meta(sc, id):
+def save_conf_creation_meta(sc, objid, status):
     engine = create_engine('mssql+pyodbc://DPHL-PROPSCORE/ListManagement?driver=SQL+Server')
-    data_package = [['Date', 'ObjId', 'SourceChannel', 'AddedToCampaign'],
-                    [time_now, id, sc, False]]
-    df = pd.DataFrame(data_package[1], data_package[0])
+    data_package = [['Date', 'ObjId', 'SourceChannel', 'Status', 'AddedToCampaign'],
+                    [time_now, objid, sc, status, False]]
+    df = pd.DataFrame(data_package[1], data_package[0]).T
     df.to_sql('ConferenceCreation', con=engine, index=False, if_exists='append')
-    engine.close()
+    engine.dispose()
+    del df
 
 
 def remove_underscores(line):

--- a/utility/pandas_helper.py
+++ b/utility/pandas_helper.py
@@ -32,6 +32,10 @@ def make_df(data=None, columns=None):
         return pd.DataFrame()
 
 
+def is_null(x):
+    return pd.isnull(x)
+
+
 def new_stat_line(value_dict):
     '''
     writes the new line of data to the stats dataframe

--- a/utility/processes.py
+++ b/utility/processes.py
@@ -130,7 +130,7 @@ def source_channel(path, record_name, obj_id, obj, aid=None, log=None):
             list_df.loc[list_df['SourceChannel'].isnull(), 'SourceChannel'] = sc_to_add
             move_to_bulk = determine_move_to_bulk_processing(list_df)
             if move_to_bulk:
-                save_conf_creation_meta(sc_to_add, obj_id)
+                save_conf_creation_meta(sc=sc_to_add, objid=obj_id, status=list_df.iloc[0, 0])
         else:
             list_df = drop_unneeded_columns(list_df, obj, create=False)
             to_create = 0

--- a/utility/processes.py
+++ b/utility/processes.py
@@ -129,6 +129,8 @@ def source_channel(path, record_name, obj_id, obj, aid=None, log=None):
             list_df.loc[list_df['AccountId'].isnull(), 'AccountId'] = obj_id
             list_df.loc[list_df['SourceChannel'].isnull(), 'SourceChannel'] = sc_to_add
             move_to_bulk = determine_move_to_bulk_processing(list_df)
+            if move_to_bulk:
+                save_conf_creation_meta(sc_to_add, obj_id)
         else:
             list_df = drop_unneeded_columns(list_df, obj, create=False)
             to_create = 0


### PR DESCRIPTION
includes patches for the below issues:

resovles #45 
When the program processes a campaign list, if there is enough information on the list to create contacts - the program will now create a record in the ListManagement Database on DPHL-PROPSCORE server in the ConferenceCreation table.

Hourly, there is a process that is triggered to associate advisors with a specific 'source_channel' to a given campaign. 

resolves #49 
simplified the processing of zipcodes by using the pandas.apply() function. it's been tested on zipcodes with the datatype of string, numeric, and float and has worked perfectly. it's not been tested on large datasets / abstract files.

Further testing is recommended, but pushing to the primary branch to accomplish this.

resolves #100 
replaced the VBA version of email handling. additionally, this process has been enchanced where it now attempts to attach files to a salesforce object - if files are attached to the email and a salesforce link is provided. 

if an email list request fails to have both a file (with an appropriate extention type) and a salesforce link, an automated response email is sent back to the originator of the list request - notifying them that their emails need to include attributes of this sort.

resolves #99 
introduces the ability to the program to attempt to identify contacts that need to be reviewed (based on a given CRD number and a salesforce CRD number not matching). 

it's recommended that this processing be further built out as new scenarios are experienced where we would want to review contacts. examples could be:

an email is provided by a list and doesn't match what we have in salesforce.

based on what the contact was matched on, we may consider having a specific to_review process for each match. would need to provide more thought to ensure a proper buildout.