### PR TITLE
gen_helper/determine_ext update

### DIFF
--- a/utility/gen_helper.py
+++ b/utility/gen_helper.py
@@ -59,9 +59,6 @@ def determine_ext(f_name):
     :return: tuple of shorten extension length and file extension
     """
     filename, file_ext = os.path.splitext(f_name)
-    if file_ext.lower() not in ['.csv', '.pdf', '.xls', '.gif', '.png', '.jpg', '.doc', '.xlsx', '.docx', '.txt', '.htm']:
-        raise BaseException('No file name, or an unknown file type,  was passed to the program.')
-
     del filename
     return len(file_ext), file_ext.lower()
 


### PR DESCRIPTION
There's currently no need (I'm aware of) to check if an extention is in
a list of values. There are other checks, in the appropriate modules, to
check for _acceptable_file_types. This check seems redudant and will
lead to the extention of the list in the function any time there is
something new that causes an error.

In an effort to streamline this to not need patch fixes, I'm removing
the check from the code base.